### PR TITLE
Don't apply hover bg change to disabled button

### DIFF
--- a/_components.buttons.scss
+++ b/_components.buttons.scss
@@ -40,7 +40,7 @@ $btn-font-family:       sans-serif !default;
         text-decoration: none; /* [4] */
     }
 
-    &:hover,
+    &:hover:not([disabled]),
     &:active,
     &:focus {
         background-color: $btn-color-bg-hover;


### PR DESCRIPTION
Having a background change on hover of a disabled button may be confusing to users.

Something I discovered recently. Is this generally a sensible change?